### PR TITLE
新增國際服支持

### DIFF
--- a/PhiCloudAction/CloudAction.py
+++ b/PhiCloudAction/CloudAction.py
@@ -19,6 +19,7 @@ class PigeonRequest:
     def __init__(
         self,
         sessionToken: Optional[str] = None,
+        isInternational: bool = False,
         client: Optional[Session] = None,
         headers: Optional[dict] = None,
     ):
@@ -31,8 +32,8 @@ class PigeonRequest:
             self.headers = headers
         else:
             self.headers = {
-                "X-LC-Id": "rAK3FfdieFob2Nn8Am",
-                "X-LC-Key": "Qr9AEqtuoSVS3zeD6iVbM4ZC0AtkJcQ89tywVyi0",
+                "X-LC-Id": "rAK3FfdieFob2Nn8Am" if not isInternational else "kviehleldgxsagpozb",
+                "X-LC-Key": "Qr9AEqtuoSVS3zeD6iVbM4ZC0AtkJcQ89tywVyi0" if not isInternational else "tG9CTm0LDD736k9HMM9lBZrbeBGRmUkjSfNLDNib",
                 "User-Agent": "LeanCloud-CSharp-SDK/1.0.3",
                 "Accept": "application/json",
                 "X-LC-Session": sessionToken,
@@ -122,7 +123,7 @@ class PigeonRequest:
 
 
 class PhigrosCloud:
-    def __init__(self, sessionToken: str, client: Optional[Any] = None):
+    def __init__(self, sessionToken: str, isInternational: bool = False, client: Optional[Any] = None):
         if checkSessionToken(sessionToken):
             self.create_client = False
             if client:
@@ -131,8 +132,11 @@ class PhigrosCloud:
                 self.client = Session()
                 self.create_client = True
 
-            self.request = PigeonRequest(sessionToken, client)
-            self.baseUrl = "https://rak3ffdi.cloud.tds1.tapapis.cn/1.1/"
+            self.request = PigeonRequest(sessionToken, isInternational, client)
+            if isInternational:
+                self.baseUrl = "https://kviehlel.cloud.ap-sg.tapapis.com/1.1/"
+            else:
+                self.baseUrl = "https://rak3ffdi.cloud.tds1.tapapis.cn/1.1/"
 
     async def __aenter__(self):
         return self

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
-packages = ["PhiCloudAction"]
+packages = ["PhiCloudAction", "PhiCloudAction.Structure"]
 
 [tool.setuptools.package-data]
 PhiCloudAction = ["info/*.tsv", "info/*.txt", "_colorlog/LICENSE"]

--- a/test/example.py
+++ b/test/example.py
@@ -13,16 +13,20 @@ from PhiCloudAction import (
     logger,
 )
 
-if len(argv) == 1:
-    sessionToken = ""
+isInternational = False
 
-else:
+if len(argv) > 1:
+    if len(argv) > 2:
+        isInternational = bool(argv[2])
+
     sessionToken = argv[1]
+else:
+    raise ValueError("未提供令牌")
 
 if __name__ == "__main__":
     updateDifficulty()
 
-    with PhigrosCloud(sessionToken) as cloud:
+    with PhigrosCloud(sessionToken, isInternational) as cloud:
         logger.info(f"玩家昵称：{cloud.getNickname()}")
 
         summary = cloud.getSummary()

--- a/test/get_save.py
+++ b/test/get_save.py
@@ -3,14 +3,19 @@ from sys import argv
 
 from PhiCloudAction import PhigrosCloud, parseSaveDict, logger
 
-if len(argv) == 1:
-    sessionToken = ""
+isInternational = False
 
-else:
+if len(argv) > 1:
+    if len(argv) > 2:
+        isInternational = bool(argv[2])
+
     sessionToken = argv[1]
+else:
+    raise ValueError("未提供令牌")
+
 
 if __name__ == "__main__":
-    with PhigrosCloud(sessionToken) as cloud:
+    with PhigrosCloud(sessionToken, isInternational) as cloud:
         save_data = cloud.getSave()
         save_dict = parseSaveDict(save_data)
         with open("PhigrosSave.json", "w", encoding="utf-8") as file:


### PR DESCRIPTION
新增了 `isInternational`可選參數到 `PigeonRequest`及 `PhigrosCloud`類，預設為false以保持兼容性

另外修改了`test/`底下的兩個測試文件，從命令行參數讀取`isInternational`參數，并且改成在沒有提供token的時候抛出異常（沒看出來用空字串符有什麽特殊意義）

并且修改了`pyproject.toml`，在`packages`屬性增加了`PhiCloudAction.Structure`（我本地構建包的時候Structure資料夾不會被包進去，如果需要改回去請指正，python 3.11.9）